### PR TITLE
Correção de erro: Aplicando cache na busca de usuários da área administrativa.

### DIFF
--- a/src/main/java/com/soulcode/goserviceapp/service/UsuarioService.java
+++ b/src/main/java/com/soulcode/goserviceapp/service/UsuarioService.java
@@ -34,7 +34,7 @@ public class UsuarioService {
         }
         throw new UsuarioNaoEncontradoException();
     }
-    @Cacheable(cacheNames = "redisCache")
+    @Cacheable(cacheNames = "redisCache2")
     public List<Usuario> findAll(){
         System.err.println("BUSCANDO USUARIOS NO BANCO DE DADOS...");
         return usuarioRepository.findAll();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.username=${USER_MYSQL}
 spring.datasource.password=${SENHA_MYSQL}
 
 # REDIS
-spring.cache.cache-names=redisCache
+spring.cache.cache-names=redisCache, redisCache2
 
 spring.cache.redis.time-to-live=180000
 spring.cache.type=redis


### PR DESCRIPTION
Para diferenciar o cachemento do método findAll de Serviços, teve que ser feita a troca do nome do cache de Usuarios, para conseguir realizar o cachemento do método findAll de Usuarios.